### PR TITLE
Redirect user when update an existing rollout

### DIFF
--- a/lib/rollout/ui/web.rb
+++ b/lib/rollout/ui/web.rb
@@ -61,7 +61,7 @@ module Rollout::UI
         end
       end
 
-      redirect feature_path(params[:feature_name])
+      redirect index_path
     end
 
     post '/features/:feature_name/activate-percentage' do


### PR DESCRIPTION
IMO is a bad user experience still be on the same page after updating a rollout. After doing it, we don't even have an Alert about the update.
![image](https://user-images.githubusercontent.com/24739860/169302015-8e15d696-fc4a-4a78-9269-fe7a8d4b1373.png)

RolloutUI has a Small Sinatra web interface. After an update, we can redirect the user to the main page, listing all rollouts, making the UX a little bit better :)