### PR TITLE
add csrf protection to forms

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,6 +3,13 @@
 require_relative 'lib/rollout/ui'
 require 'redis'
 
+require "rack/protection"
+use Rack::Session::Cookie,
+  key: 'rack.session',
+  path: '/',
+  secret: ENV.fetch('SECRET_KEY_BASE', 'development_secret_key_base_123456789012345678901234567890123456789012345678901234567890')
+use Rack::Protection::AuthenticityToken
+
 redis_host = ENV.fetch('REDIS_HOST', 'localhost')
 redis_port = ENV.fetch('REDIS_PORT', '6379')
 redis_db = ENV.fetch('REDIS_DB', '10')

--- a/lib/rollout/ui/helpers.rb
+++ b/lib/rollout/ui/helpers.rb
@@ -5,6 +5,10 @@ require "rollout/ui/version"
 
 module Rollout::UI
   module Helpers
+    def csrf_token
+      session[:csrf] ||= Rack::Protection::AuthenticityToken.random_token
+    end
+    
     def stylesheet_path(name)
       "#{request.script_name}/css/#{name}.css"
     end

--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -45,12 +45,15 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
               span title=@rollout.logging.updated_at(feature_name).strftime(Rollout::UI.config.timestamp_format) = time_ago(@rollout.logging.updated_at(feature_name))
           td.flex.items-center.py-2.justify-end.whitespace-no-wrap.pl-3
             form action=activate_percentage_feature_path(feature_name, 100) method='POST'
+              input type="hidden" name="authenticity_token" value="#{csrf_token}"
               button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 100%?')")
                 ' 100%
             form action=activate_percentage_feature_path(feature_name, 0) method='POST'
+              input type="hidden" name="authenticity_token" value="#{csrf_token}"
               button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 0%?')")
                 ' 0%
             form action=delete_feature_path(feature_name) method='POST'
+              input type="hidden" name="authenticity_token" value="#{csrf_token}"
               button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want to delete #{sanitized_name(feature_name)}?')")
                 ' Delete
 

--- a/lib/rollout/ui/views/features/new.slim
+++ b/lib/rollout/ui/views/features/new.slim
@@ -6,6 +6,8 @@ h2.font-semibold.text-xl.text-gray-500.pt-12
 .w-8.h-1.bg-gray-300.my-10
 
 form.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm action=new_feature_path method='POST'
+  input type="hidden" name="authenticity_token" value="#{csrf_token}"
+  
   .mb-5
     label.block.text-gray-500.mb-2(for='name') Name
     input.appearance-none.border.rounded-sm.w-full.py-2.px-4.text-gray-600.leading-relaxed.bg-white(name='name' id='name' class='hover:border-gray-500')

--- a/lib/rollout/ui/views/features/show.slim
+++ b/lib/rollout/ui/views/features/show.slim
@@ -9,6 +9,7 @@ h2.font-semibold.text-xl.text-gray-500.pt-12
 .w-8.h-1.bg-gray-300.my-10
 main.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm
   form#updateFormSubmit action=feature_path(@feature.name) method='POST'
+    input type="hidden" name="authenticity_token" value="#{csrf_token}"
     input type='hidden' name='last_updated_at' value=(@feature.data['updated_at'])
     .mb-5
       label.block.text-gray-500.mb-2(for='description') Description
@@ -63,6 +64,7 @@ main.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm
 
   .flex.items-center.justify-end
     form action=delete_feature_path(@feature.name) method='POST'
+      input type="hidden" name="authenticity_token" value="#{csrf_token}"
       button.mr-5.text-gray-600(class='hover:underline' type='submit' onclick="return confirm('Are you sure you want to delete #{sanitized_name(@feature.name)}?')")
         | Delete
     button.py-4.px-5.bg-gray-700.text-gray-200.rounded-sm.font-bold.leading-none.transition-colors.duration-200(

--- a/lib/rollout/ui/web.rb
+++ b/lib/rollout/ui/web.rb
@@ -11,6 +11,10 @@ module Rollout::UI
     set :static, true
     set :public_folder, File.dirname(__FILE__) + '/public'
 
+    enable :sessions
+    set :protection, except: :http_origin
+    use Rack::Protection::AuthenticityToken
+
     helpers Helpers
 
     get '/' do

--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -116,4 +116,119 @@ RSpec.describe 'Web UI' do
 
     ROLLOUT.delete(:fake_test_feature_for_rollout_ui_webspec)
   end
+
+  describe "CSRF Protection" do
+    it "blocks POST without authenticity_token" do
+      get "/features/new"
+
+      post "/features/new", { name: "beta_feature" }
+
+      expect(last_response.status).to eq(403)
+    end
+
+    it "blocks POST with invalid authenticity_token" do
+      get "/features/new"
+
+      post "/features/new", {
+        name: "fake_feature",
+        authenticity_token: "invalid-token"
+      }
+
+      expect(last_response.status).to eq(403)
+    end
+
+    it "allows POST with valid authenticity_token" do
+      get "/features/new"
+      token = last_request.env['rack.session'][:csrf]
+
+      post "/features/new", {
+        name: "secure_feature",
+        authenticity_token: token
+      }
+
+      expect(last_response.status).to eq(302)
+      follow_redirect!
+      expect(last_response.body).to include("secure_feature")
+    end
+
+    it "blocks POST to update feature without authenticity_token" do
+      ROLLOUT.activate(:test_feature)
+      get "/features/test_feature"
+
+      post "/features/test_feature", {
+        percentage: 50,
+        groups: ["test_group"]
+      }
+
+      expect(last_response.status).to eq(403)
+      ROLLOUT.delete(:test_feature)
+    end
+
+    it "blocks POST to update feature with invalid authenticity_token" do
+      ROLLOUT.activate(:test_feature)
+      get "/features/test_feature"
+
+      post "/features/test_feature", {
+        percentage: 50,
+        groups: ["test_group"],
+        authenticity_token: "invalid-token"
+      }
+
+      expect(last_response.status).to eq(403)
+      ROLLOUT.delete(:test_feature)
+    end
+
+    it "allows POST to update feature with valid authenticity_token" do
+      ROLLOUT.activate(:test_feature)
+      get "/features/test_feature"
+      token = last_request.env['rack.session'][:csrf]
+
+      post "/features/test_feature", {
+        percentage: 50,
+        groups: ["test_group"],
+        authenticity_token: token
+      }
+
+      expect(last_response.status).to eq(302)
+      follow_redirect!
+      expect(last_response.body).to include("test_feature")
+      ROLLOUT.delete(:test_feature)
+    end
+
+    it "blocks POST to delete feature without authenticity_token" do
+      ROLLOUT.activate(:test_feature)
+      get "/features/test_feature"
+
+      post "/features/test_feature/delete"
+
+      expect(last_response.status).to eq(403)
+      ROLLOUT.delete(:test_feature)
+    end
+
+    it "blocks POST to delete feature with invalid authenticity_token" do
+      ROLLOUT.activate(:test_feature)
+      get "/features/test_feature"
+
+      post "/features/test_feature/delete", {
+        authenticity_token: "invalid-token"
+      }
+
+      expect(last_response.status).to eq(403)
+      ROLLOUT.delete(:test_feature)
+    end
+
+    it "allows POST to delete feature with valid authenticity_token" do
+      ROLLOUT.activate(:test_feature)
+      get "/features/test_feature"
+      token = last_request.env['rack.session'][:csrf]
+
+      post "/features/test_feature/delete", {
+        authenticity_token: token
+      }
+
+      expect(last_response.status).to eq(302)
+      follow_redirect!
+      expect(last_response.body).not_to include("test_feature")
+    end
+  end
 end


### PR DESCRIPTION
**This Pull Request adds an additional layer of security to rollout-ui by implementing Cross-Site Request Forgery (CSRF) protection for all operations that modify the state of features.**

**Changes Made:**
* Use Rack::Protection::AuthenticityToken to protect agains CSRF.
* Change all forms to include the CSRF token hidden input.

Test Updates: Tests have been added to ensure that CSRF protection works correctly, and requests without a valid token are properly rejected.