### PR TITLE
Sanitize params[:error] to prevent reflected XSS

### DIFF
--- a/lib/rollout/ui/views/features/show.slim
+++ b/lib/rollout/ui/views/features/show.slim
@@ -2,7 +2,7 @@ a.text-sm.text-blue-600(href=index_path class='hover:text-blue-700 hover:underli
   ' &larr; back to overview
 
 - if params[:error]
-  pre.text-red-500= params[:error]
+  pre.text-red-500= sanitized_name(params[:error].strip)
 h2.font-semibold.text-xl.text-gray-500.pt-12
   = @feature.name
 


### PR DESCRIPTION
This PR uses the existing sanitized_name helper to escape params[:error] before rendering it in the feature.slim template.

This prevents reflected XSS attacks by ensuring untrusted input is safely HTML-escaped.

Before:
?error=<script>alert(1)</script> rendered raw HTML.

After:
The error is escaped using sanitized_name(params[:error].strip), which relies on Rack::Utils.escape_html.

No new methods introduced — just applying the gem’s own helper for safe output.